### PR TITLE
Mostrar ejemplos y agregar root key a la respuesta.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ namespace :sepomex do
 
     puts 'Extracting Zip'
     Zip::File.open('latest.zip') do |zip_file|
-      zip_file.extract('CPdescarga.txt', 'latest.csv')
+      zip_file.extract('CPdescarga.txt', 'latest.csv') { true }
     end
 
     puts 'Parsing Postal Codes'

--- a/Readme.md
+++ b/Readme.md
@@ -1,26 +1,78 @@
 # API para los códigos postales de México
 
 Dado un código postal, regresa un arreglo con las colonia, municipio y estado perteneciente al código postal.
+Además se pueden realizar búsquedas de códigos postales usando los números iniciales.
 
-Ej.
-`https://api-codigos-postales.herokuapp.com/codigo_postal/64630`
-Regresa:
+### Ejemplos de uso
+
+#### Liga a la API
+
+[https://api-codigos-postales.herokuapp.com](https://api-codigos-postales.herokuapp.com)
+
+
+
+** Consultar la información de un código postal **
+
+```text
+https://api-codigos-postales.herokuapp.com/codigo_postal
+```
+
+** Respuesta del servidor **
 ```json
-[
-    {
+{
+    "codigos_postales":
+    [
+      {
         "codigo_postal": "64630",
         "colonia": "Colinas de San Jerónimo",
         "municipio": "Monterrey",
         "estado": "Nuevo León"
-    },
-    {
+      },
+      {
         "codigo_postal": "64630",
         "colonia": "San Jemo 1 Sector",
         "municipio": "Monterrey",
         "estado": "Nuevo León"
-    }
-]
+      }
+    ]
+}
 ```
+
+---
+
+** Buscar códigos postales **
+
+```text
+ https://api-codigos-postales.herokuapp.com/buscar
+```
+
+_parametros necesarios_
+```text
+  codigo_postal=# codigo a buscar, parcial o total
+```
+_ Ejemplo de busqueda para códigos que inicien con **66**, con **664** y con **6641** _
+```json
+https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=66
+https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=664
+https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=6641
+```
+
+** El servidor regresa **
+```json
+{
+    "codigos_postales":
+    [
+      {
+        "codigo_postal": "66400",
+      },
+      {
+        "codigo_postal": "66409"
+      }
+    ]
+}
+```
+
+___
 
 ### Colabora
 Errores y pull requests son bienvenidos en Github: https://github.com/Munett/API-Codigos-Postales.

--- a/Readme.md
+++ b/Readme.md
@@ -14,25 +14,20 @@ Además se pueden realizar búsquedas de códigos postales usando los números i
 **Consultar la información de un código postal**
 
 ```text
-https://api-codigos-postales.herokuapp.com/codigo_postal/64630
+https://api-codigos-postales.herokuapp.com/codigo_postal/66436
 ```
 
 **Respuesta del servidor**
 ```json
-[
-  {
-    "codigo_postal": "64630",
-    "colonia": "Colinas de San Jerónimo",
-    "municipio": "Monterrey",
-    "estado": "Nuevo León"
-  },
-  {
-    "codigo_postal": "64630",
-    "colonia": "San Jemo 1 Sector",
-    "municipio": "Monterrey",
-    "estado": "Nuevo León"
-  }
-]
+{
+  "codigo_postal": "66436",
+  "municipio": "San Nicolás de los Garza",
+  "estado": "Nuevo León",
+  "colonias": [
+    "Praderas de Santo Domingo",
+    "Las Nuevas Puente"
+  ]
+}
 ```
 
 ---
@@ -54,19 +49,19 @@ https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=664
 https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=6641
 ```
 
-** El servidor regresa **
+** Para el codigo postal 6641 el servidor regresa **
 ```json
-[
-  {
-    "codigo_postal": "66400"
-  },
-  {
-    "codigo_postal": "66409"
-  },
-  {
-    ...
-  }
-]
+{
+  "codigos_postales": [
+    "66410",
+    "66412",
+    "66413",
+    "66414",
+    "66415",
+    "66417",
+    "66418"
+  ]
+}
 ```
 
 ___

--- a/Readme.md
+++ b/Readme.md
@@ -11,36 +11,33 @@ Además se pueden realizar búsquedas de códigos postales usando los números i
 
 
 
-** Consultar la información de un código postal **
+**Consultar la información de un código postal**
 
 ```text
-https://api-codigos-postales.herokuapp.com/codigo_postal
+https://api-codigos-postales.herokuapp.com/codigo_postal/64630
 ```
 
-** Respuesta del servidor **
+**Respuesta del servidor**
 ```json
-{
-    "codigos_postales":
-    [
-      {
-        "codigo_postal": "64630",
-        "colonia": "Colinas de San Jerónimo",
-        "municipio": "Monterrey",
-        "estado": "Nuevo León"
-      },
-      {
-        "codigo_postal": "64630",
-        "colonia": "San Jemo 1 Sector",
-        "municipio": "Monterrey",
-        "estado": "Nuevo León"
-      }
-    ]
-}
+[
+  {
+    "codigo_postal": "64630",
+    "colonia": "Colinas de San Jerónimo",
+    "municipio": "Monterrey",
+    "estado": "Nuevo León"
+  },
+  {
+    "codigo_postal": "64630",
+    "colonia": "San Jemo 1 Sector",
+    "municipio": "Monterrey",
+    "estado": "Nuevo León"
+  }
+]
 ```
 
 ---
 
-** Buscar códigos postales **
+**Buscar códigos postales**
 
 ```text
  https://api-codigos-postales.herokuapp.com/buscar
@@ -50,7 +47,7 @@ _parametros necesarios_
 ```text
   codigo_postal=# codigo a buscar, parcial o total
 ```
-_ Ejemplo de busqueda para códigos que inicien con **66**, con **664** y con **6641** _
+_Ejemplo de busqueda para códigos que inicien con **66**, con **664** y con **6641**_
 ```json
 https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=66
 https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=664
@@ -59,17 +56,17 @@ https://api-codigos-postales.herokuapp.com/buscar?codigo_postal=6641
 
 ** El servidor regresa **
 ```json
-{
-    "codigos_postales":
-    [
-      {
-        "codigo_postal": "66400",
-      },
-      {
-        "codigo_postal": "66409"
-      }
-    ]
-}
+[
+  {
+    "codigo_postal": "66400"
+  },
+  {
+    "codigo_postal": "66409"
+  },
+  {
+    ...
+  }
+]
 ```
 
 ___

--- a/app.rb
+++ b/app.rb
@@ -9,18 +9,14 @@ Cuba.define do
       res.headers['Cache-Control'] = 'max-age=525600, public'
       res.headers['Content-Type'] = 'application/json; charset=utf-8'
       res.headers['Access-Control-Allow-Origin'] = '*'
-      res.write Oj.dump(PostalCode.where(codigo_postal: codigo_postal)
-        .as_json(except: :id), mode: :object)
+      res.write PostalCodes.fetch_locations(codigo_postal)
     end
 
-    on 'buscar', param('q') do |query|
+    on 'buscar', param('codigo_postal') do |codigo_postal|
       res.headers['Cache-Control'] = 'max-age=525600, public'
       res.headers['Content-Type'] = 'application/json; charset=utf-8'
       res.headers['Access-Control-Allow-Origin'] = '*'
-      res.write Oj.dump(PostalCode.select('DISTINCT codigo_postal')
-        .where('codigo_postal LIKE :prefix', prefix: "#{query}%")
-        .order('codigo_postal ASC')
-        .as_json(except: :id), mode: :object)
+      res.write PostalCodes.fetch_codes(codigo_postal)
     end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -8,6 +8,7 @@ require 'cuba'
 require './db'
 require './app'
 require './models/postal_code'
+require './presenters/postal_codes'
 
 if ENV['RACK_ENV'] == 'production'
   require 'rack/ssl'

--- a/models/postal_code.rb
+++ b/models/postal_code.rb
@@ -1,3 +1,23 @@
 class PostalCode < ActiveRecord::Base
   self.table_name = 'codigos_postales'
+
+  scope :with_code,
+    -> (code) { where(codigo_postal: code) }
+
+  scope :with_code_hint,
+    -> (code_hint) {
+      where("codigo_postal LIKE :prefix", prefix: "#{code_hint}%")
+      .order(codigo_postal: :asc)
+      .distinct
+      .pluck(:codigo_postal)
+     }
+
+  def self.get_suburbs_for(code)
+    PostalCode.with_code(code).pluck(:colonia)
+  end
+
+  def self.get_shared_data_for(code)
+    PostalCode.with_code(code).limit(1).pluck(:municipio, :estado)
+  end
+
 end

--- a/presenters/postal_codes.rb
+++ b/presenters/postal_codes.rb
@@ -2,7 +2,8 @@ module PostalCodes
 
   def self.fetch_codes(code)
     postal_codes = search_postal_codes(code)
-    serialize(postal_codes)
+    postal_codes_json = prepare_json(postal_codes)
+    serialize(postal_codes_json)
   end
 
   def self.search_postal_codes(code)
@@ -13,16 +14,20 @@ module PostalCodes
 
   def self.fetch_locations(code)
     locations = search_locations(code)
-    serialize(locations)
+    locations_json = prepare_json(locations)
+    serialize(locations_json)
   end
 
   def self.search_locations(code)
     locations = PostalCode.where(codigo_postal: code)
   end
 
+  def self.prepare_json(data)
+    data.as_json(except: :id)
+  end
+
   def self.serialize(data)
-    json = { 'codigos_postales' => data.as_json(except: :id) }
-    Oj.dump(json, mode: :object)
+    Oj.dump(data, mode: :object)
   end
 
 end

--- a/presenters/postal_codes.rb
+++ b/presenters/postal_codes.rb
@@ -1,0 +1,28 @@
+module PostalCodes
+
+  def self.fetch_codes(code)
+    postal_codes = search_postal_codes(code)
+    serialize(postal_codes)
+  end
+
+  def self.search_postal_codes(code)
+    postal_codes = PostalCode.select('DISTINCT codigo_postal')
+      .where('codigo_postal LIKE :prefix', prefix: "#{code}%")
+      .order('codigo_postal ASC')
+  end
+
+  def self.fetch_locations(code)
+    locations = search_locations(code)
+    serialize(locations)
+  end
+
+  def self.search_locations(code)
+    locations = PostalCode.where(codigo_postal: code)
+  end
+
+  def self.serialize(data)
+    json = { 'codigos_postales' => data.as_json(except: :id) }
+    Oj.dump(json, mode: :object)
+  end
+
+end

--- a/presenters/postal_codes.rb
+++ b/presenters/postal_codes.rb
@@ -2,28 +2,41 @@ module PostalCodes
 
   def self.fetch_codes(code)
     postal_codes = search_postal_codes(code)
-    postal_codes_json = prepare_json(postal_codes)
+    postal_codes_json = prepare_postal_codes_json(postal_codes)
     serialize(postal_codes_json)
   end
 
   def self.search_postal_codes(code)
-    postal_codes = PostalCode.select('DISTINCT codigo_postal')
-      .where('codigo_postal LIKE :prefix', prefix: "#{code}%")
-      .order('codigo_postal ASC')
+    postal_codes = PostalCode.with_code_hint(code)
   end
 
   def self.fetch_locations(code)
     locations = search_locations(code)
-    locations_json = prepare_json(locations)
+    shared_data = shared_data(code)
+    locations_json = prepare_locations_json(locations, code, shared_data)
     serialize(locations_json)
   end
 
   def self.search_locations(code)
-    locations = PostalCode.where(codigo_postal: code)
+    locations = PostalCode.get_suburbs_for(code)
   end
 
-  def self.prepare_json(data)
-    data.as_json(except: :id)
+  def self.shared_data(code)
+    shared_data = PostalCode.get_shared_data_for(code)
+    shared_data.flatten!
+    shared_data = ["",""] if shared_data.empty?
+    shared_data
+  end
+
+  def self.prepare_locations_json(locations, code, shared_data)
+    { "codigo_postal" => code,
+      "municipio" => shared_data[0],
+      "estado" => shared_data[1],
+      "colonias" => locations }
+  end
+
+  def self.prepare_postal_codes_json(codes)
+    { "codigos_postales" => codes }
   end
 
   def self.serialize(data)


### PR DESCRIPTION
* Propongo agregar una la llave root _codigos_postales_ a las respuestas en pro de las buenas practicas, para esto, agregar código que ayude a la abstracción. [liga](https://github.com/rubixware/API-Codigos-Postales/blob/readme-search/presenters/postal_codes.rb)

* Cambiar un poco el README para incluir los ejemplos de uso para ambos casos existentes. [liga](https://github.com/rubixware/API-Codigos-Postales/blob/readme-search/Readme.md)

* En la tarea de `sepomex:update` permitir la idempotencia sobreescribiendo el `latest.csv`con cada uso. [liga](https://github.com/rubixware/API-Codigos-Postales/blob/readme-search/Rakefile#L43)